### PR TITLE
Swap stray threads for a thread pool.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,5 +11,5 @@ tasks.register('buildEverything', GradleBuild) {
 
 allprojects {
     group = 'gg.paynow'
-    version = '0.0.6'
+    version = '0.0.7'
 }

--- a/paynow-bukkit/src/main/java/gg/paynow/paynowbukkit/PayNowBukkit.java
+++ b/paynow-bukkit/src/main/java/gg/paynow/paynowbukkit/PayNowBukkit.java
@@ -1,6 +1,7 @@
 package gg.paynow.paynowbukkit;
 
 import gg.paynow.paynowlib.PayNowLib;
+import gg.paynow.paynowlib.PayNowUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -42,6 +43,7 @@ public class PayNowBukkit extends JavaPlugin {
     @Override
     public void onDisable() {
         if(runnableId != -1) this.getServer().getScheduler().cancelTask(runnableId);
+        PayNowUtils.ASYNC_EXEC.shutdown();
     }
 
     private void startRunnable() {

--- a/paynow-bukkit/src/main/resources/plugin.yml
+++ b/paynow-bukkit/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: PayNow
 author: PayNow
-version: 0.0.6
+version: 0.0.7
 main: gg.paynow.paynowbukkit.PayNowBukkit
 
 commands:

--- a/paynow-bungeecord/src/main/java/gg/paynow/paynowbungee/PayNowBungee.java
+++ b/paynow-bungeecord/src/main/java/gg/paynow/paynowbungee/PayNowBungee.java
@@ -1,6 +1,7 @@
 package gg.paynow.paynowbungee;
 
 import gg.paynow.paynowlib.PayNowLib;
+import gg.paynow.paynowlib.PayNowUtils;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ListenerInfo;
@@ -49,6 +50,7 @@ public class PayNowBungee extends Plugin {
     @Override
     public void onDisable() {
         if(runnableId != -1) ProxyServer.getInstance().getScheduler().cancel(runnableId);
+        PayNowUtils.ASYNC_EXEC.shutdown();
     }
 
     private void startRunnable() {

--- a/paynow-bungeecord/src/main/resources/bungee.yml
+++ b/paynow-bungeecord/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: paynow
-version: 0.0.6
+version: 0.0.7
 author: PayNow
 main: gg.paynow.paynowbungee.PayNowBungee

--- a/paynow-fabric/gradle.properties
+++ b/paynow-fabric/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.10
 loader_version=0.15.11
 # Mod Properties
-mod_version=0.0.6
+mod_version=0.0.7
 maven_group=gg.paynow
 archives_base_name=paynow-fabric
 # Dependencies

--- a/paynow-fabric/src/main/java/gg/paynow/paynowfabric/PayNowFabric.java
+++ b/paynow-fabric/src/main/java/gg/paynow/paynowfabric/PayNowFabric.java
@@ -1,6 +1,7 @@
 package gg.paynow.paynowfabric;
 
 import gg.paynow.paynowlib.PayNowLib;
+import gg.paynow.paynowlib.PayNowUtils;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -58,6 +59,8 @@ public class PayNowFabric implements DedicatedServerModInitializer {
             lastCheck = this.payNowLib.getConfig().getApiCheckInterval() * 20;
             this.check();
         });
+
+        ServerLifecycleEvents.SERVER_STOPPING.register((__) -> PayNowUtils.ASYNC_EXEC.shutdown());
     }
 
     private void check() {

--- a/paynow-lib/src/main/java/gg/paynow/paynowlib/PayNowLib.java
+++ b/paynow-lib/src/main/java/gg/paynow/paynowlib/PayNowLib.java
@@ -92,7 +92,7 @@ public class PayNowLib {
                 return body;
             };
 
-            Thread thread = new Thread(() -> {
+            PayNowUtils.ASYNC_EXEC.submit(() -> {
                 try {
                     String responseBody = client.execute(request, responseHandler);
 
@@ -101,7 +101,6 @@ public class PayNowLib {
                     severe("Failed to fetch commands: error executing request");
                 }
             });
-            thread.start();
         } catch (UnsupportedEncodingException e) {
             severe("Error while fetching pending commands.");
             e.printStackTrace();
@@ -173,14 +172,13 @@ public class PayNowLib {
                 return body;
             };
 
-            Thread thread = new Thread(() -> {
+            PayNowUtils.ASYNC_EXEC.submit(() -> {
                 try {
                     client.execute(request, responseHandler);
                 } catch (IOException e) {
                     severe("Failed to fetch commands: error executing request");
                 }
             });
-            thread.start();
         } catch (UnsupportedEncodingException e) {
             severe("Error while fetching pending commands.");
             e.printStackTrace();
@@ -221,7 +219,7 @@ public class PayNowLib {
                 return body;
             };
 
-            Thread thread = new Thread(() -> {
+            PayNowUtils.ASYNC_EXEC.submit(() -> {
                 try {
                     String responseBody = client.execute(request, responseHandler);
                     log(responseBody);
@@ -230,11 +228,9 @@ public class PayNowLib {
                     severe("Failed to fetch commands: error executing request");
                 }
             });
-            thread.start();
         } catch (UnsupportedEncodingException e) {
             severe("Error while fetching pending commands.");
             e.printStackTrace();
-            return;
         }
     }
 

--- a/paynow-lib/src/main/java/gg/paynow/paynowlib/PayNowLib.java
+++ b/paynow-lib/src/main/java/gg/paynow/paynowlib/PayNowLib.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 
 public class PayNowLib {
 
-    private static final String VERSION = "0.0.6";
+    private static final String VERSION = "0.0.7";
 
     private static final URI API_QUEUE_URL = URI.create("https://api.paynow.gg/v1/delivery/command-queue/");
     private static final URI API_LINK_URL = URI.create("https://api.paynow.gg/v1/delivery/gameserver/link");

--- a/paynow-lib/src/main/java/gg/paynow/paynowlib/PayNowUtils.java
+++ b/paynow-lib/src/main/java/gg/paynow/paynowlib/PayNowUtils.java
@@ -1,6 +1,16 @@
 package gg.paynow.paynowlib;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 public class PayNowUtils {
+    public static final ExecutorService ASYNC_EXEC = Executors.newFixedThreadPool(4,
+            runnable -> {
+                Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+                thread.setName("PayNow-ThreadPool");
+                thread.setDaemon(true);
+                return thread;
+            });
 
     public static boolean isSuccess(int statusCode) {
         return statusCode >= 200 && statusCode < 300;

--- a/paynow-sponge/src/main/java/gg/paynow/paynowsponge/PayNowSponge.java
+++ b/paynow-sponge/src/main/java/gg/paynow/paynowsponge/PayNowSponge.java
@@ -2,6 +2,7 @@ package gg.paynow.paynowsponge;
 
 import com.google.inject.Inject;
 import gg.paynow.paynowlib.PayNowLib;
+import gg.paynow.paynowlib.PayNowUtils;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
@@ -108,6 +109,7 @@ public class PayNowSponge {
     @Listener
     public void onServerStopping(final StoppingEngineEvent<Server> event) {
         if (this.task != null) this.task.cancel();
+        PayNowUtils.ASYNC_EXEC.shutdown();
     }
 
     public void triggerConfigUpdate(){

--- a/paynow-velocity/src/main/java/gg/paynow/paynowvelocity/PayNowVelocity.java
+++ b/paynow-velocity/src/main/java/gg/paynow/paynowvelocity/PayNowVelocity.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 @Plugin(
         id = "paynow-velocity",
         name = "PayNow",
-        version = "0.0.6",
+        version = "0.0.7",
         authors = {"PayNow"},
         url = "https://paynow.gg"
 )

--- a/paynow-velocity/src/main/java/gg/paynow/paynowvelocity/PayNowVelocity.java
+++ b/paynow-velocity/src/main/java/gg/paynow/paynowvelocity/PayNowVelocity.java
@@ -13,6 +13,7 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import gg.paynow.paynowlib.PayNowLib;
+import gg.paynow.paynowlib.PayNowUtils;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -78,6 +79,7 @@ public class PayNowVelocity {
     @Subscribe
     public void onProxyShutdown(ProxyShutdownEvent event) {
         if (this.task != null) this.task.cancel();
+        PayNowUtils.ASYNC_EXEC.shutdown();
     }
 
     private void startRunnable() {


### PR DESCRIPTION
Swaps creation of threads in favor of a thread pool.

Pros:
  - Reuses threads that have already been created instead of creating new ones (an expensive process that can easily harm server performance)
  - Keeps the number of threads the plugin may spawn to a maximum of 4.

Cons:
  - We must shut down the thread pool on server stop, meaning we must declare it in every mod.